### PR TITLE
Set linker.fileLayout to "linear" to emulate old behavior

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -6,6 +6,8 @@ const {traverse, isMethod, isFunction, isTypedef, isProperty} = require("@webdoc
 
 const linker = new LinkerPlugin();
 
+linker.fileLayout = "linear";
+
 exports.linker = linker;
 
 /**


### PR DESCRIPTION
This will fix the issue with the file layout changing when upgrading webdoc. (related https://github.com/webdoc-labs/webdoc/issues/117)