### PR TITLE
Bump markdown-it-highlightjs from 3.4.0 to 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "klaw-sync": "^6.0.0",
         "lodash": "*",
         "markdown-it": "^12.3.2",
-        "markdown-it-highlightjs": "^3.4.0",
+        "markdown-it-highlightjs": "^3.6.0",
         "missionlog": "^1.6.0",
         "open-sans-fonts": "^1.6.2",
         "taffydb": "^2.7.3"
@@ -1803,11 +1803,11 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
-      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -2296,11 +2296,11 @@
       }
     },
     "node_modules/markdown-it-highlightjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-highlightjs/-/markdown-it-highlightjs-3.4.0.tgz",
-      "integrity": "sha512-JES5P8ll3Vpf6a4C0FlsaO1opOaH53Rbvphj2IAON29v33cHNUiwXBSaC+bThUiLp6m3UEZ4vv579CHSElWSdw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-highlightjs/-/markdown-it-highlightjs-3.6.0.tgz",
+      "integrity": "sha512-ex+Lq3cVkprh0GpGwFyc53A/rqY6GGzopPCG1xMsf8Ya3XtGC8Uw9tChN1rWbpyDae7tBBhVHVcMM29h4Btamw==",
       "dependencies": {
-        "highlight.js": "^10.2.0",
+        "highlight.js": "^11.3.1",
         "lodash.flow": "^3.5.0"
       }
     },
@@ -5136,9 +5136,9 @@
       }
     },
     "highlight.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
-      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw=="
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw=="
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -5534,11 +5534,11 @@
       }
     },
     "markdown-it-highlightjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-highlightjs/-/markdown-it-highlightjs-3.4.0.tgz",
-      "integrity": "sha512-JES5P8ll3Vpf6a4C0FlsaO1opOaH53Rbvphj2IAON29v33cHNUiwXBSaC+bThUiLp6m3UEZ4vv579CHSElWSdw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-highlightjs/-/markdown-it-highlightjs-3.6.0.tgz",
+      "integrity": "sha512-ex+Lq3cVkprh0GpGwFyc53A/rqY6GGzopPCG1xMsf8Ya3XtGC8Uw9tChN1rWbpyDae7tBBhVHVcMM29h4Btamw==",
       "requires": {
-        "highlight.js": "^10.2.0",
+        "highlight.js": "^11.3.1",
         "lodash.flow": "^3.5.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "klaw-sync": "^6.0.0",
     "lodash": "*",
     "markdown-it": "^12.3.2",
-    "markdown-it-highlightjs": "^3.4.0",
+    "markdown-it-highlightjs": "^3.6.0",
     "missionlog": "^1.6.0",
     "open-sans-fonts": "^1.6.2",
     "taffydb": "^2.7.3"


### PR DESCRIPTION
`markdown-it-highlightjs` version `3.4.0` will cause this warning in console:

```
Deprecated as of 10.7.0. highlight(lang, code, ...args) has been deprecated.
Deprecated as of 10.7.0. Please use highlight(code, options) instead.
https://github.com/highlightjs/highlight.js/issues/2277
```

So bump it to a newer version `3.6.0`.

See also: https://github.com/pixijs/pixijs/issues/8720#issuecomment-1279691366