### PR TITLE
Add missing URL scheme

### DIFF
--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -30,9 +30,9 @@
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
-    <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.3/styles/googlecode.min.css">
+    <link type="text/css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.3/styles/googlecode.min.css">
+    <link type="text/css" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,700">
     <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
-    <link href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,700" rel="stylesheet">
     <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
     <link type="text/css" rel="stylesheet" href="styles/bootstrap.min.css">
     <link type="text/css" rel="stylesheet" href="styles/main.css">


### PR DESCRIPTION
See also: https://github.com/webdoc-labs/webdoc/pull/196

---

The URL scheme is missing for `googlecode.min.css`:

```html
<link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.3/styles/googlecode.min.css">
```

It works fine on a real website, but if you open the output `.html` file locally, the browser will assume the scheme is `file:`, causing the error:

![image](https://user-images.githubusercontent.com/8724868/198843286-cb912121-7347-499a-ade7-da7a1c0624d5.png)

Adding an explicit `https:` solves the problem.
