### PR TITLE
Improve Navigation Search

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -45,6 +45,10 @@ $(function() {
   const $nav = $(".navigation");
   const $list = $nav.find(".list");
   const $search = $(".search");
+  const $items = $nav.find(".item");
+
+  // Store the original ordering of the items
+  const originalOrder = $items.toArray();
 
   // Search input
   $("#search").on("keyup", function(e) {
@@ -55,6 +59,8 @@ $(function() {
     });
 
     const value = this.value.trim();
+    const valueLowerCase = value.toLowerCase();
+
     if (value) {
       const regexp = new RegExp(value, "i");
       $nav.addClass("searching")
@@ -77,18 +83,34 @@ $(function() {
             $title.addClass("highlight");
             highlight($title, value);
             // Highlight the nested member elements for the nested sub-groups
-            $item.children(".parent.match > a").each(function(i, v) {
+            $item.children(".match > a").each(function(i, v) {
               $(v).addClass("highlight");
               highlight($(v), value);
             });
           }
         }
       });
+
+      // Order the list items
+      $items.sort(function(a, b) {
+        const aText = $(a).text().toLowerCase();
+        const bText = $(b).text().toLowerCase();
+        const aIndex = aText.indexOf(valueLowerCase);
+        const bIndex = bText.indexOf(valueLowerCase);
+
+        if (aIndex === -1) return 1;
+        if (bIndex === -1) return -1;
+        return aIndex - bIndex;
+      });
+      $(".list").append($items);
     } else {
       $nav.removeClass("searching")
         .addClass("not-searching")
         .find(".item, .itemMembers")
         .removeClass("match");
+
+      // Restore original items ordering
+      $(".list").empty().append(originalOrder);
     }
     $list.scrollTop(0);
   });

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -1,1 +1,141 @@
-(function(){var e=0;var a;var t=document.getElementById("source-code");if(t){var n=config.linenums;if(n){t=t.getElementsByTagName("ol")[0];a=Array.prototype.slice.apply(t.children);a=a.map(function(a){e++;a.id="line"+e})}else{t=t.getElementsByTagName("code")[0];a=t.innerHTML.split("\n");a=a.map(function(a){e++;return'<span id="line'+e+'"></span>'+a});t.innerHTML=a.join("\n")}}})();$(function(){var e=$(".navigation");var a=e.find(".list");var t=$(".search");$("#search").on("keyup",function(t){var n=this.value.trim();if(n){var s=new RegExp(n,"i");e.addClass("searching").removeClass("not-searching").find("li, .itemMembers").removeClass("match");e.find("li").each(function(e,a){var t=$(a);if(t.data("name")&&s.test(t.data("name"))){t.addClass("match");t.closest(".itemMembers").addClass("match");t.closest(".item").addClass("match")}})}else{e.removeClass("searching").addClass("not-searching").find(".item, .itemMembers").removeClass("match")}a.scrollTop(0)});$("#menuToggle").click(function(){a.toggleClass("show");t.toggleClass("show")});e.addClass("not-searching");var n=$(".page-title").data("filename").replace(/\.[a-z]+$/,"");var s=e.find(".item[data-name=\"" + n + "\"]:eq(0)");if(!s.length)s=e.find('a[href*="'+n+'"]:eq(0)').closest(".item");if(s.length){if(s.parents(".children").length){s.addClass("current");s.find("li.item").addClass("notCurrent");s=s.parents("ul.list>li.item")}s.remove().prependTo(a).addClass("current")}if(config.disqus){$(window).on("load",function(){var e=config.disqus;var a=document.createElement("script");a.type="text/javascript";a.async=true;a.src="http://"+e+".disqus.com/embed.js";(document.getElementsByTagName("head")[0]||document.getElementsByTagName("body")[0]).appendChild(a);var t=document.createElement("script");t.async=true;t.type="text/javascript";t.src="http://"+e+".disqus.com/count.js";document.getElementsByTagName("BODY")[0].appendChild(t)})}});
+(function() {
+  let e=0;
+  let a;
+  let t=document.getElementById("source-code");
+
+  if (t) {
+    const n=config.linenums;
+
+    if (n) {
+      t=t.getElementsByTagName("ol")[0];
+      a=Array.prototype.slice.apply(t.children);
+      a=a.map(function(a) {
+        e++; a.id="line"+e;
+      });
+    } else {
+      t=t.getElementsByTagName("code")[0];
+      a=t.innerHTML.split("\n");
+      a=a.map(function(a) {
+        e++; return "<span id=\"line"+e+"\"></span>"+a;
+      });
+      t.innerHTML=a.join("\n");
+    }
+  }
+})();
+
+function highlight(anchor, textToHighlight) {
+  const originalText = anchor.text();
+  const indexOfMatch = originalText.toLowerCase().indexOf(textToHighlight.toLowerCase());
+
+  if (indexOfMatch >= 0) {
+    // Split the text into three parts: before the match, the match, and after the match
+    const beforeMatch = originalText.slice(0, indexOfMatch);
+    const matchText = originalText.slice(indexOfMatch, indexOfMatch + textToHighlight.length);
+    const afterMatch = originalText.slice(indexOfMatch + textToHighlight.length);
+
+    // Create a new HTML string with the match wrapped in a span
+    const newHtml = beforeMatch + "<span>" + matchText + "</span>" + afterMatch;
+
+    // Set the new HTML to the anchor element
+    anchor.html(newHtml);
+  }
+}
+
+$(function() {
+  const $nav = $(".navigation");
+  const $list = $nav.find(".list");
+  const $search = $(".search");
+
+  // Search input
+  $("#search").on("keyup", function(e) {
+    // Clear any highlights
+    $nav.find("a.highlight").each(function(i, v) {
+      $(v).find("span").first().contents().unwrap();
+      $(v).removeClass("highlight");
+    });
+
+    const value = this.value.trim();
+    if (value) {
+      const regexp = new RegExp(value, "i");
+      $nav.addClass("searching")
+        .removeClass("not-searching")
+        .find("li, .itemMembers")
+        .removeClass("match");
+
+      $nav.find("li").each(function(i, v) {
+        const $item = $(v);
+        const name = $item.data("name");
+
+        if (name) {
+          const extracted = name.split(".").pop();
+          if (regexp.test(extracted)) {
+            $item.addClass("match");
+            $item.closest(".itemMembers").addClass("match");
+            $item.closest(".item").addClass("match");
+            // Highlight the nested title element for the top-level item
+            const $title = $($item.find(".title > a").first());
+            $title.addClass("highlight");
+            highlight($title, value);
+            // Highlight the nested member elements for the nested sub-groups
+            $item.children(".parent.match > a").each(function(i, v) {
+              $(v).addClass("highlight");
+              highlight($(v), value);
+            });
+          }
+        }
+      });
+    } else {
+      $nav.removeClass("searching")
+        .addClass("not-searching")
+        .find(".item, .itemMembers")
+        .removeClass("match");
+    }
+    $list.scrollTop(0);
+  });
+
+  $("#menuToggle").click(function() {
+    $list.toggleClass("show");
+    $search.toggleClass("show");
+  });
+
+  // Show an item related a current documentation automatically
+  $nav.addClass("not-searching");
+  const filename = $(".page-title").data("filename").replace(/\.[a-z]+$/, "");
+
+  // Directly matching the filename and the top-level item's data-name attribute.
+  let $currentItem = $nav.find(".item[data-name=\"" + filename + "\"]:eq(0)");
+
+  // Fallback to default querying for the likes of interfaces which doesn't have its own top-level navigation item.
+  if (!$currentItem.length) {
+    $currentItem = $nav.find("a[href*=\"" + filename + "\"]:eq(0)").closest(".item");
+  }
+
+  if ($currentItem.length) {
+    // if a child then show the top level parent and highlight the
+    // current item.
+    if ($currentItem.parents(".children").length) {
+      $currentItem.addClass("current");
+      // need to make all children not current
+      $currentItem.find("li.item").addClass("notCurrent");
+      $currentItem = $currentItem.parents("ul.list>li.item");
+    }
+    $currentItem
+      .remove()
+      .prependTo($list)
+      .addClass("current");
+  }
+
+  // disqus code
+  if (config.disqus) {
+    $(window).on("load", function() {
+      const disqus_shortname = config.disqus; // required: replace example with your forum shortname
+      const dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
+      dsq.src = "http://" + disqus_shortname + ".disqus.com/embed.js";
+      (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(dsq);
+      const s = document.createElement("script"); s.async = true;
+      s.type = "text/javascript";
+      s.src = "http://" + disqus_shortname + ".disqus.com/count.js";
+      document.getElementsByTagName("BODY")[0].appendChild(s);
+    });
+  }
+});

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -1,1 +1,503 @@
-body,html{font-family:'Libre Franklin',sans-serif;background-color:#ecedf1;color:#333}ol,ul{margin:0;padding:0}li{list-style-type:none}#wrap{position:relative}.list::-webkit-scrollbar{width:8px;background-color:transparent}.list::-webkit-scrollbar-thumb{background-color:#647086;border-radius:4px}.navigation{position:fixed;overflow:hidden;min-width:250px;width:25%;top:0;left:0;bottom:0;background-color:#272d37}.navigation .menu-toggle{display:none}@media screen and (max-width:768px){.navigation{left:0;position:relative;width:100%;overflow:auto}.navigation .list,.navigation .search{display:none}.navigation .list.show,.navigation .search.show{display:block;position:static}.navigation .menu-toggle{display:block;position:absolute;top:10px;right:10px}}.navigation .applicationName{margin:0;padding:20px;font-weight:700;white-space:nowrap;color:#fff}.navigation .applicationName a{color:#fff}.navigation .search{padding:0 20px}.navigation .search input{background-color:#14171d;color:#fff;border-color:#3d495a}.navigation .list{padding:20px;position:absolute;overflow:auto;-webkit-overflow-scrolling:touch;width:100%;top:100px;bottom:0}.navigation li.item{margin-bottom:8px;padding-bottom:8px;border-bottom:1px solid #3d495a;overflow:hidden}.navigation li.item a{color:#647086}.navigation li.item a:hover{color:#fff}.navigation li.item .title{display:block}.navigation li.item .title a{display:block;color:#cfd4db}.navigation li.item .title a:hover{color:#fff}.navigation li.item .title.namespace a{color:#fff}.navigation li.item .title .namespaceTag{display:inline-block;border-radius:3px;background-color:#c2185b;color:#fff;font-size:70%;padding:2px 6px;float:left;margin-right:10px;pointer-events:none}.navigation li.item .subtitle{margin:10px 0;font-weight:700;color:#c2185b;display:block;letter-spacing:.05em}.navigation li.item ul>li{padding-left:10px;font-size:.9em}.navigation li.item .itemMembers li.parent a{color:#a9b3c3}.navigation .children li.item{border-bottom:none;padding-bottom:0}.navigation .children li.notCurrent{font-weight:400}.navigation .children li.current{font-weight:700}.navigation .item,.navigation .itemMembers,.navigation .itemMembers li{display:none}.navigation.not-searching .item{display:block}.navigation.not-searching .item.current .itemMembers,.navigation.not-searching .item.current .itemMembers li{display:block}.navigation.searching .item.match{display:block}.navigation.searching .item.match .itemMembers li.match,.navigation.searching .item.match .itemMembers.match{display:block}.content-size{max-width:1000px;min-width:300px;margin-left:auto;margin-right:auto}.status-deprecated{text-decoration:line-through;opacity:.4}.status-deprecated a,.status-deprecated:hover{text-decoration:none}.main{left:25%;position:fixed;height:100%;right:0;overflow:auto;-webkit-overflow-scrolling:touch;word-break:break-word}.main .summary-list dt{width:100%;margin-bottom:4px;float:left;font-size:110%}@media screen and (min-width:768px){.main .summary-list dt{width:50%}}@media screen and (min-width:991px){.main .summary-list dt{width:33.33%}}@media screen and (min-width:1200px){.main .summary-list dt{width:25%}}@media screen and (max-width:1000px){.main{left:250px}}@media screen and (max-width:768px){.main{left:0;position:static}}.main img{max-width:100%}.main article{padding:20px}.main header{background:#fff}.main header .class-description{font-size:120%}.main header .header{padding:20px}.main header .header h2{font-weight:700}.main .page-title{display:none}.main .access-signature{font-weight:400;display:inline-block;border-radius:3px;background-color:#79859a;color:#fff;font-size:.7em;padding:2px 6px;margin-left:6px}.main .access-signature.deprecated{background-color:#e91e63;font-weight:700}.main .access-signature.deprecated .deprecated-info{font-weight:400;margin-left:5px}.main .access-signature a{color:#fff}.main h4.name .type-signature{font-weight:400;font-size:.8em;color:#79859a}.main h4.name .type-signature:before{content:' : ';opacity:.6}.main h4.name .return-symbol{margin:0 6px;color:#79859a;font-size:80%}.main h4.name .share-icon{font-size:70%;color:#79859a}.main .subsection-title{color:#e91e63}.main .description{margin-top:10px}.main .description ol,.main .description ul{margin-bottom:15px}.main .description h2{font-weight:700;margin-top:30px;margin-bottom:10px;padding-bottom:10px;border-bottom:1px solid #efefef}.main .description pre{margin:10px 0}.main .tag-source{font-size:85%}.main dt.tag-source{margin-top:5px}.main dt.tag-default{color:#79859a}.main .nameContainer{position:relative}.main .nameContainer .tag-source{position:absolute;top:0;right:0;padding:2px 6px;border-bottom-left-radius:4px;border-bottom-right-radius:4px;background-color:#b3b7c3}.main .nameContainer .tag-source a{color:#fff;font-weight:400}.main .nameContainer h4{font-weight:700;padding:20px 0 0;border-top:1px solid #c8c9cc}.main .nameContainer h4 .signature{font-weight:400;font-size:.8em;padding-left:.4em}.main table{width:100%;margin-bottom:15px;margin-top:5px}.main table th{padding:3px 3px;color:#fff;font-weight:400;background:#79859a}.main table td{vertical-align:top;padding:5px 3px;word-break:normal}.main table tbody tr:nth-child(odd){background-color:#fff}.main table tbody tr:nth-child(even){background-color:#f5f5fb}.main table .type{color:#79859a}.main table .attributes{color:#79859a}.main table .description p{margin:0}.main table .optional{float:left;border-radius:3px;background-color:#b3b7c3;padding:2px 4px;margin-right:5px;color:#fff;font-size:80%}.main .readme p{margin-top:15px}.main .readme h1{font-weight:700}.main .readme h2{font-weight:700;margin-top:30px;margin-bottom:10px;padding-bottom:10px;border-bottom:1px solid #79859a}.main .readme h3{color:#e91e63}.main .readme li{margin-bottom:10px}.main article ol,.main article ul{margin-left:25px}.main article ol>li{list-style-type:decimal;margin-bottom:5px}.main article ul>li{margin-bottom:5px;list-style-type:disc}.footer{margin:0 20px 20px;padding-top:20px;text-align:right;font-size:.9em;color:#79859a;border-top:1px solid #c8c9cc}
+body,html {
+	font-family: 'Libre Franklin',sans-serif;
+	background-color: #ecedf1;
+	color: #333
+}
+
+ol,ul {
+	margin: 0;
+	padding: 0
+}
+
+li {
+	list-style-type: none
+}
+
+#wrap {
+	position: relative
+}
+
+.list::-webkit-scrollbar {
+	width: 8px;
+	background-color: transparent
+}
+
+.list::-webkit-scrollbar-thumb {
+	background-color: #647086;
+	border-radius: 4px
+}
+
+.navigation {
+	position: fixed;
+	overflow: hidden;
+	min-width: 250px;
+	width: 25%;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	background-color: #272d37
+}
+
+.navigation .menu-toggle {
+	display: none
+}
+
+@media screen and (max-width:768px) {
+	.navigation {
+		left: 0;
+		position: relative;
+		width: 100%;
+		overflow: auto
+	}
+
+	.navigation .list,.navigation .search {
+		display: none
+	}
+
+	.navigation .list.show,.navigation .search.show {
+		display: block;
+		position: static
+	}
+
+	.navigation .menu-toggle {
+		display: block;
+		position: absolute;
+		top: 10px;
+		right: 10px
+	}
+}
+
+.navigation .applicationName {
+	margin: 0;
+	padding: 20px;
+	font-weight: 700;
+	white-space: nowrap;
+	color: #fff
+}
+
+.navigation .applicationName a {
+	color: #fff
+}
+
+.navigation .search {
+	padding: 0 20px
+}
+
+.navigation .search input {
+	background-color: #14171d;
+	color: #fff;
+	border-color: #3d495a
+}
+
+.navigation .list {
+	padding: 20px;
+	position: absolute;
+	overflow: auto;
+	-webkit-overflow-scrolling: touch;
+	width: 100%;
+	top: 100px;
+	bottom: 0
+}
+
+.navigation li.item {
+	margin-bottom: 8px;
+	padding-bottom: 8px;
+	border-bottom: 1px solid #3d495a;
+	overflow: hidden
+}
+
+.navigation li.item a {
+	color: #647086
+}
+
+.navigation li.item a.highlight span {
+	color: #333;
+	background-color: #FFFF00;
+    border-radius: 0.4rem;
+    padding: 0.15rem;
+}
+
+.navigation li.item a:hover {
+	color: #fff
+}
+
+.navigation li.item .title {
+	display: block
+}
+
+.navigation li.item .title a {
+	display: block;
+	color: #cfd4db
+}
+
+.navigation li.item .title a:hover {
+	color: #fff
+}
+
+.navigation li.item .title.namespace a {
+	color: #fff
+}
+
+.navigation li.item .title .namespaceTag {
+	display: inline-block;
+	border-radius: 3px;
+	background-color: #c2185b;
+	color: #fff;
+	font-size: 70%;
+	padding: 2px 6px;
+	float: left;
+	margin-right: 10px;
+	pointer-events: none
+}
+
+.navigation li.item .subtitle {
+	margin: 10px 0;
+	font-weight: 700;
+	color: #c2185b;
+	display: block;
+	letter-spacing: .05em
+}
+
+.navigation li.item ul>li {
+	padding-left: 10px;
+	font-size: .9em
+}
+
+.navigation li.item .itemMembers li.parent a {
+	color: #a9b3c3
+}
+
+.navigation .children li.item {
+	border-bottom: none;
+	padding-bottom: 0
+}
+
+.navigation .children li.notCurrent {
+	font-weight: 400
+}
+
+.navigation .children li.current {
+	font-weight: 700
+}
+
+.navigation .item,.navigation .itemMembers,.navigation .itemMembers li {
+	display: none
+}
+
+.navigation.not-searching .item {
+	display: block
+}
+
+.navigation.not-searching .item.current .itemMembers,.navigation.not-searching .item.current .itemMembers li {
+	display: block
+}
+
+.navigation.searching .item.match {
+	display: block
+}
+
+.navigation.searching .item.match .itemMembers li.match,.navigation.searching .item.match .itemMembers.match {
+	display: block
+}
+
+.content-size {
+	max-width: 1000px;
+	min-width: 300px;
+	margin-left: auto;
+	margin-right: auto
+}
+
+.status-deprecated {
+	text-decoration: line-through;
+	opacity: .4
+}
+
+.status-deprecated a,.status-deprecated:hover {
+	text-decoration: none
+}
+
+.main {
+	left: 25%;
+	position: fixed;
+	height: 100%;
+	right: 0;
+	overflow: auto;
+	-webkit-overflow-scrolling: touch;
+	word-break: break-word
+}
+
+.main .summary-list dt {
+	width: 100%;
+	margin-bottom: 4px;
+	float: left;
+	font-size: 110%
+}
+
+@media screen and (min-width:768px) {
+	.main .summary-list dt {
+		width: 50%
+	}
+}
+
+@media screen and (min-width:991px) {
+	.main .summary-list dt {
+		width: 33.33%
+	}
+}
+
+@media screen and (min-width:1200px) {
+	.main .summary-list dt {
+		width: 25%
+	}
+}
+
+@media screen and (max-width:1000px) {
+	.main {
+		left: 250px
+	}
+}
+
+@media screen and (max-width:768px) {
+	.main {
+		left: 0;
+		position: static
+	}
+}
+
+.main img {
+	max-width: 100%
+}
+
+.main article {
+	padding: 20px
+}
+
+.main header {
+	background: #fff
+}
+
+.main header .class-description {
+	font-size: 120%
+}
+
+.main header .header {
+	padding: 20px
+}
+
+.main header .header h2 {
+	font-weight: 700
+}
+
+.main .page-title {
+	display: none
+}
+
+.main .access-signature {
+	font-weight: 400;
+	display: inline-block;
+	border-radius: 3px;
+	background-color: #79859a;
+	color: #fff;
+	font-size: .7em;
+	padding: 2px 6px;
+	margin-left: 6px
+}
+
+.main .access-signature.deprecated {
+	background-color: #e91e63;
+	font-weight: 700
+}
+
+.main .access-signature.deprecated .deprecated-info {
+	font-weight: 400;
+	margin-left: 5px
+}
+
+.main .access-signature a {
+	color: #fff
+}
+
+.main h4.name .type-signature {
+	font-weight: 400;
+	font-size: .8em;
+	color: #79859a
+}
+
+.main h4.name .type-signature:before {
+	content: ' : ';
+	opacity: .6
+}
+
+.main h4.name .return-symbol {
+	margin: 0 6px;
+	color: #79859a;
+	font-size: 80%
+}
+
+.main h4.name .share-icon {
+	font-size: 70%;
+	color: #79859a
+}
+
+.main .subsection-title {
+	color: #e91e63
+}
+
+.main .description {
+	margin-top: 10px
+}
+
+.main .description ol,.main .description ul {
+	margin-bottom: 15px
+}
+
+.main .description h2 {
+	font-weight: 700;
+	margin-top: 30px;
+	margin-bottom: 10px;
+	padding-bottom: 10px;
+	border-bottom: 1px solid #efefef
+}
+
+.main .description pre {
+	margin: 10px 0
+}
+
+.main .tag-source {
+	font-size: 85%
+}
+
+.main dt.tag-source {
+	margin-top: 5px
+}
+
+.main dt.tag-default {
+	color: #79859a
+}
+
+.main .nameContainer {
+	position: relative
+}
+
+.main .nameContainer .tag-source {
+	position: absolute;
+	top: 0;
+	right: 0;
+	padding: 2px 6px;
+	border-bottom-left-radius: 4px;
+	border-bottom-right-radius: 4px;
+	background-color: #b3b7c3
+}
+
+.main .nameContainer .tag-source a {
+	color: #fff;
+	font-weight: 400
+}
+
+.main .nameContainer h4 {
+	font-weight: 700;
+	padding: 20px 0 0;
+	border-top: 1px solid #c8c9cc
+}
+
+.main .nameContainer h4 .signature {
+	font-weight: 400;
+	font-size: .8em;
+	padding-left: .4em
+}
+
+.main table {
+	width: 100%;
+	margin-bottom: 15px;
+	margin-top: 5px
+}
+
+.main table th {
+	padding: 3px 3px;
+	color: #fff;
+	font-weight: 400;
+	background: #79859a
+}
+
+.main table td {
+	vertical-align: top;
+	padding: 5px 3px;
+	word-break: normal
+}
+
+.main table tbody tr:nth-child(odd) {
+	background-color: #fff
+}
+
+.main table tbody tr:nth-child(even) {
+	background-color: #f5f5fb
+}
+
+.main table .type {
+	color: #79859a
+}
+
+.main table .attributes {
+	color: #79859a
+}
+
+.main table .description p {
+	margin: 0
+}
+
+.main table .optional {
+	float: left;
+	border-radius: 3px;
+	background-color: #b3b7c3;
+	padding: 2px 4px;
+	margin-right: 5px;
+	color: #fff;
+	font-size: 80%
+}
+
+.main .readme p {
+	margin-top: 15px
+}
+
+.main .readme h1 {
+	font-weight: 700
+}
+
+.main .readme h2 {
+	font-weight: 700;
+	margin-top: 30px;
+	margin-bottom: 10px;
+	padding-bottom: 10px;
+	border-bottom: 1px solid #79859a
+}
+
+.main .readme h3 {
+	color: #e91e63
+}
+
+.main .readme li {
+	margin-bottom: 10px
+}
+
+.main article ol,.main article ul {
+	margin-left: 25px
+}
+
+.main article ol>li {
+	list-style-type: decimal;
+	margin-bottom: 5px
+}
+
+.main article ul>li {
+	margin-bottom: 5px;
+	list-style-type: disc
+}
+
+.footer {
+	margin: 0 20px 20px;
+	padding-top: 20px;
+	text-align: right;
+	font-size: .9em;
+	color: #79859a;
+	border-top: 1px solid #c8c9cc
+}

--- a/tmpl/components/container-navigation.tmpl
+++ b/tmpl/components/container-navigation.tmpl
@@ -10,7 +10,7 @@ var canStyleAsNamespace = function(item) {
         <span class="glyphicon glyphicon-menu-hamburger"></span>
     </button>
     <div class="search">
-        <input id="search" type="text" class="form-control input-md" placeholder="Search...">
+        <input id="search" type="text" class="form-control input-md" placeholder="Search..." autocomplete="off">
     </div>
     <ul class="list">
     <?js


### PR DESCRIPTION
Resolves [ticket](https://github.com/orgs/pixijs/projects/2/views/4?pane=issue&itemId=46052296).

- Remove parent prefixes on the name data when comparing with the search term to prevent from showing absolutely every members within the main items. Essentially showing only the matched items/members.
- Add partial highlight on the matched term on the items/members. (Currently is using the flat `#FFFF00` yellow which looks fine but let me know if we have a specific colour for the highlight in the design guideline)
- Now basic sorts of the list top items to prioritise direct matches over member matches. Here, Levenshtein distance function will yield better sorting but was discarded due to simplicity and performance.
- Turn `autocomplete` off on the search input to prevent persisting search value when navigating back the pages.
- Note: I prettified `main.js` and `main.css` for readability, since we might be doing more tweaks moving forward.

# Preview

[Build Link](http://pixi-v8-docs-search-improvements-preview.surge.sh)

https://github.com/pixijs/webdoc-template/assets/4834594/d1bd27db-f957-4e5d-bcd7-fcf9d1049b3b
