### PR TITLE
Align Example Code Blocks' Background Colour

### DIFF
--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -1,5 +1,5 @@
 .hljs {
-  background-color: inherit;
+  background-color: #f5f5f5;
 }
 
 pre {


### PR DESCRIPTION
- The inconsistency of the code blocks' background colour is due to them being different element, ie. some example codes are from JSDoc example tag while others are from markdown code syntax (```js).
<img width="661" alt="Screenshot 2023-12-08 at 14 38 36" src="https://github.com/pixijs/webdoc-template/assets/4834594/53600adc-d954-4482-8340-20b1c389e952">
- Here, the `.hljs` element background colour is explicitly set to align with that of JSDoc example's `pre` blocks.
<img width="661" alt="Screenshot 2023-12-08 at 14 48 20" src="https://github.com/pixijs/webdoc-template/assets/4834594/253d5dbe-b471-4ca2-9540-9033012a8f73">
- Note this will also change align the background colour of the code blocks on the headers as well which will make them stand out from the section white background
<img width="661" alt="Screenshot 2023-12-08 at 14 39 50" src="https://github.com/pixijs/webdoc-template/assets/4834594/38fedfee-4920-44a2-a8a2-55cef78eed15">
