### PR TITLE
Add Property Type Formatting

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -160,4 +160,13 @@ $(function() {
       document.getElementsByTagName("BODY")[0].appendChild(s);
     });
   }
+
+  // Manually scroll to hash, in case it was attempted before the content was loaded.
+  if (window.location.hash) {
+    const hash = window.location.hash;
+    const el = document.querySelector(hash);
+    if (el) {
+      el.scrollIntoView();
+    }
+  }
 });

--- a/static/styles/property-types.css
+++ b/static/styles/property-types.css
@@ -1,0 +1,41 @@
+.properties .type, .params .type, .properties .default {
+    font-family: monospace !important;
+    font-size: 12px !important;
+    color: #6e6eb5 !important;
+}
+
+.properties .type a:hover, .params .type a:hover {
+    text-decoration: underline !important;
+}
+
+.properties .default {
+    color: #96b59d !important;
+}
+
+.hljs-built_in, .hljs-title.class_, .hljs-variable.constant_, .hljs-property {
+    color: #6e6eb5 !important;
+}
+
+.hljs-title.class_ {
+    color: #4444b9 !important;
+}
+
+.hljs-attr {
+    color: red !important;
+}
+
+.properties .default {
+    color: #009e38 !important;
+}
+
+.hljs-title {
+    font-weight: normal !important;
+}
+
+.share-icon {
+    padding-top: 15px;
+}
+
+.hljs-keyword {
+    color: inherit !important;
+}

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -37,6 +37,7 @@
     <link type="text/css" rel="stylesheet" href="styles/bootstrap.min.css">
     <link type="text/css" rel="stylesheet" href="styles/main.css">
     <link type="text/css" rel="stylesheet" href="styles/collapsible-group.css">
+    <link type="text/css" rel="stylesheet" href="styles/property-types.css">
     <?js if (env.conf.templates) { ?>
     <script>
     var config = <?js= JSON.stringify(env.conf.templates) ?>;


### PR DESCRIPTION
Resolves [ticket](https://github.com/orgs/pixijs/projects/2/views/4?pane=issue&itemId=46875538).

- Wrap and style function type's parameters to highlight them out.
<img width="933" alt="Screenshot 2023-12-08 at 17 52 11" src="https://github.com/pixijs/webdoc-template/assets/4834594/e5daae36-2e37-4717-bbc1-e38359d10dab">

- Break object notation properties into its own line for readability.
<img width="933" alt="Screenshot 2023-12-08 at 17 51 50" src="https://github.com/pixijs/webdoc-template/assets/4834594/81a384d2-0595-46ca-8bfc-20dcc5b9de1b">
<img width="933" alt="Screenshot 2023-12-08 at 17 52 01" src="https://github.com/pixijs/webdoc-template/assets/4834594/69b67721-ba84-4cd3-a4e5-a5896f30ce6d">

- Add styling overrides accordingly.
- Add manual navigation to hash element section on page loaded as a fallback for when the page is not focused on the correct section.