### PR TITLE
Fix: Add missing registry-url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
             - name: Use Node.js 18.x
               uses: actions/setup-node@v3
               with:
+                  registry-url: 'https://registry.npmjs.org'
                   node-version: 18
                   cache: 'npm'
             - name: Install Dependencies


### PR DESCRIPTION
Missed this `registry-url` property causing 2.2.0 to fail: https://github.com/pixijs/webdoc-template/actions/runs/7234872947/job/19711674833