### PR TITLE
Hotfix: Remove Parental Prefixes from link texts of { @link } Tags

### DIFF
--- a/src/utils/overrides.ts
+++ b/src/utils/overrides.ts
@@ -174,8 +174,6 @@ export function overrideLinkerPlugin()
 
         if (linkText && typeof linkText !== 'string')
         {
-            console.log('linkText:', linkText.name);
-
             linkText = linkText.name;
         }
 

--- a/src/utils/overrides.ts
+++ b/src/utils/overrides.ts
@@ -131,7 +131,7 @@ export function overrideLinkerPlugin()
         {
             return `<a href=${encodeURI(
                 this.queryCache.get(docPath) || ''
-            )}>${linkText}</a>`;
+            )}>${removeParentalPrefix(linkText)}</a>`;
         }
 
         if (isDataType(docPath))
@@ -174,6 +174,8 @@ export function overrideLinkerPlugin()
 
         if (linkText && typeof linkText !== 'string')
         {
+            console.log('linkText:', linkText.name);
+
             linkText = linkText.name;
         }
 


### PR DESCRIPTION
Resolves [ticket](https://github.com/orgs/pixijs/projects/2/views/4?pane=issue&itemId=47840592).